### PR TITLE
Timx 369 core status checks

### DIFF
--- a/abdiff/core/build_ab_images.py
+++ b/abdiff/core/build_ab_images.py
@@ -7,6 +7,7 @@ import docker.models.images
 from pygit2 import clone_repository
 from pygit2.enums import ResetMode
 
+from abdiff.core.exceptions import InvalidRepositoryCommitSHAError
 from abdiff.core.utils import update_or_create_job_json
 
 logger = logging.getLogger(__name__)
@@ -92,10 +93,17 @@ def clone_repo_and_reset_to_commit(clone_directory: str, commit_sha: str) -> Non
         commit_sha: The SHA of a repo commit.
     """
     logger.debug(f"Cloning repo to: {clone_directory}")
+    transmogrifier_url = "https://github.com/MITLibraries/transmogrifier.git"
     repository = clone_repository(
-        "https://github.com/MITLibraries/transmogrifier.git",
+        transmogrifier_url,
         clone_directory,
     )
     logger.debug(f"Cloned repo to: {clone_directory}")
-    repository.reset(commit_sha, ResetMode.HARD)
-    logger.debug(f"Cloned repo reset to commit: {commit_sha}")
+
+    try:
+        repository.reset(commit_sha, ResetMode.HARD)
+        logger.debug(f"Cloned repo reset to commit: {commit_sha}")
+    except KeyError as exception:
+        raise InvalidRepositoryCommitSHAError(
+            transmogrifier_url, commit_sha
+        ) from exception

--- a/abdiff/core/exceptions.py
+++ b/abdiff/core/exceptions.py
@@ -19,8 +19,6 @@ class DockerContainerRuntimeExceededTimeoutError(Exception):
 
 
 # core function errors
-
-
 class DockerContainerRunFailedError(Exception):
     def __init__(self, containers: list) -> None:
         self.containers = containers
@@ -33,13 +31,13 @@ class DockerContainerRunFailedError(Exception):
         )
 
 
-class OutputValidationError(Exception):
-    def __init__(self, message: str):
-        super().__init__(message)
-
-
 class InvalidRepositoryCommitSHAError(Exception):
     def __init__(self, repository: str, commit_sha: str):
         super().__init__(
             f"Cannot reset repository ({repository}) to an invalid commit SHA: {commit_sha}."  # noqa: E501
         )
+
+
+class OutputValidationError(Exception):
+    def __init__(self, message: str):
+        super().__init__(message)

--- a/abdiff/core/exceptions.py
+++ b/abdiff/core/exceptions.py
@@ -16,3 +16,10 @@ class DockerContainerRuntimeExceededTimeoutError(Exception):
             f"{len(container_ids)} container(s) is/are still running:"
             f"{container_ids}."
         )
+
+
+class InvalidRepositoryCommitSHAError(Exception):
+    def __init__(self, repository: str, commit_sha: str):
+        super().__init__(
+            f"Cannot reset repository ({repository}) to an invalid commit SHA: {commit_sha}."  # noqa: E501
+        )

--- a/abdiff/core/exceptions.py
+++ b/abdiff/core/exceptions.py
@@ -18,6 +18,26 @@ class DockerContainerRuntimeExceededTimeoutError(Exception):
         )
 
 
+# core function errors
+
+
+class DockerContainerRunFailedError(Exception):
+    def __init__(self, containers: list) -> None:
+        self.containers = containers
+        super().__init__(self.get_formatted_message())
+
+    def get_formatted_message(self) -> str:
+        return (
+            f"The following Docker containers exited with an error: {self.containers}. "
+            "Check the logs in transformed/logs.txt to identify the error."
+        )
+
+
+class OutputValidationError(Exception):
+    def __init__(self, message: str):
+        super().__init__(message)
+
+
 class InvalidRepositoryCommitSHAError(Exception):
     def __init__(self, repository: str, commit_sha: str):
         super().__init__(

--- a/abdiff/core/run_ab_transforms.py
+++ b/abdiff/core/run_ab_transforms.py
@@ -249,20 +249,22 @@ def get_transformed_files(run_directory: str) -> tuple[list[str], ...]:
 
 
 def validate_output(
-    ab_transformed_file_lists: tuple[list[str], ...], expected_file_count: int
+    ab_transformed_file_lists: tuple[list[str], ...], input_files_count: int
 ) -> None:
     """Validate the output of run_ab_transforms.
 
-    This function checks that the number of files in the A/B transformed file
-    directories matches expected file count (i.e., the number of input files).
+    This function checks that the number of files in each of the A/B
+    transformed file directories matches the number of input files
+    provided to run_ab_transforms (i.e., the expected number of
+    files that are transformed).
     """
     if any(
-        len(transformed_files) != expected_file_count
+        len(transformed_files) != input_files_count
         for transformed_files in ab_transformed_file_lists
     ):
         raise OutputValidationError(  # noqa: TRY003
             "At least one or more transformed JSON file(s) are missing. "
-            f"Expecting {expected_file_count} transformed JSON file(s)."
+            f"Expecting {input_files_count} transformed JSON file(s)."
             "Check the transformed file directories."
         )
 

--- a/abdiff/core/run_ab_transforms.py
+++ b/abdiff/core/run_ab_transforms.py
@@ -13,7 +13,11 @@ import docker
 from docker.models.containers import Container
 
 from abdiff.config import Config
-from abdiff.core.exceptions import DockerContainerRuntimeExceededTimeoutError
+from abdiff.core.exceptions import (
+    DockerContainerRunFailedError,
+    DockerContainerRuntimeExceededTimeoutError,
+    OutputValidationError,
+)
 from abdiff.core.utils import create_subdirectories, update_or_create_run_json
 
 CONFIG = Config()
@@ -38,8 +42,11 @@ def run_ab_transforms(
            running in parallel.
         3. Wait for all containers to complete.
         4. Aggregate logs from all containers.
-        5. Update run.json with lists describing input and transformed files.
-        5. Return a tuple containing two lists representing all A and B transformed files.
+        5. If any containers exit, raise an error listing the IDs for failed
+           containers.
+        6. Validate the number of files in the A/B transformed file directories.
+        7. Update run.json with lists describing input and transformed files.
+        8. Return a tuple containing two lists representing all A and B transformed files.
 
     Args:
         run_directory (str): Run directory.
@@ -101,22 +108,31 @@ def run_ab_transforms(
             )
             containers.append(container)
 
-    wait_for_containers(containers, timeout)
+    failed_containers = wait_for_containers(containers, timeout)
     logger.info(f"All {len(containers)} containers have exited.")
 
     log_file = aggregate_logs(run_directory, containers)
     logger.info(f"Log file created: {log_file}")
 
-    transformed_files = get_transformed_files(run_directory)
+    # errors from failed containers are accessible via aggregated logs
+    if failed_containers:
+        raise DockerContainerRunFailedError(failed_containers)
 
-    run_data = {"input_files": input_files, "transformed_files": transformed_files}
+    ab_transformed_file_lists = get_transformed_files(run_directory)
+
+    validate_output(ab_transformed_file_lists, len(input_files))
+
+    run_data = {
+        "input_files": input_files,
+        "transformed_files": ab_transformed_file_lists,
+    }
     update_or_create_run_json(run_directory, run_data)
 
     elapsed_time = perf_counter() - start_time
     logger.info(
         "Total time to complete process: %s", str(timedelta(seconds=elapsed_time))
     )
-    return transformed_files
+    return ab_transformed_file_lists
 
 
 def run_docker_container(
@@ -155,13 +171,21 @@ def run_docker_container(
     return container
 
 
-def wait_for_containers(containers: list[Container], timeout: int = 180) -> None:
-    """Given a list of running containers, wait until all containers exit."""
-    exited_containers: list[Container] = []
+def wait_for_containers(
+    containers: list[Container], timeout: int = 180
+) -> None | list[str]:
+    """Given a list of running containers, wait until all containers exit.
+
+    If there are any containers that exited with an error, a list of IDs
+    for failed containers is returned. For more information regarding the
+    specific cause of the error, consult the logs.
+    """
+    exited_containers: list[str] = []
+    failed_containers: list[str] = []
     start_time = time.time()
     while len(exited_containers) < len(containers):
         running_containers = [
-            container for container in containers if container not in exited_containers
+            container for container in containers if container.id not in exited_containers
         ]
         if time.time() - start_time >= timeout:
             raise DockerContainerRuntimeExceededTimeoutError(
@@ -171,8 +195,20 @@ def wait_for_containers(containers: list[Container], timeout: int = 180) -> None
             container.reload()
             if container.status == "exited":
                 logger.info(f"Container {container.id} exited.")
-                exited_containers.append(container)
+                exited_containers.append(container.id)  # type: ignore[arg-type]
+                if (exit_code := container.attrs["State"]["ExitCode"]) == 0:
+                    logger.info(f"Container {container.id} ran successfully.")
+                else:
+                    logger.error(
+                        f"Container {container.id} exited with an error: {exit_code}. "
+                        "Check logs for details."
+                    )
+                    failed_containers.append(container.id)  # type: ignore[arg-type]
         time.sleep(0.25)
+
+    if any(failed_containers):
+        return failed_containers
+    return None
 
 
 def aggregate_logs(run_directory: str, containers: list[Container]) -> str:
@@ -180,12 +216,13 @@ def aggregate_logs(run_directory: str, containers: list[Container]) -> str:
     log_file = str(Path(run_directory) / "transformed/logs.txt")
     with open(log_file, "w") as file:
         for container in containers:
-            header = (
+            file.write(f"container: {container.id}\n")
+            descriptors = (
                 f"docker_image: {container.labels['docker_image']} | "
                 f"source: {container.labels['source']} | "
                 f"input_file: {container.labels['input_file']}\n"
             )
-            file.write(header)
+            file.write(descriptors)
             file.write(container.logs().decode())
             file.write("\n\n")
     return log_file
@@ -209,6 +246,25 @@ def get_transformed_files(run_directory: str) -> tuple[list[str], ...]:
         ]
         ordered_files.append(relative_filepaths)
     return tuple(ordered_files)
+
+
+def validate_output(
+    ab_transformed_file_lists: tuple[list[str], ...], expected_file_count: int
+) -> None:
+    """Validate the output of run_ab_transforms.
+
+    This function checks that the number of files in the A/B transformed file
+    directories matches expected file count (i.e., the number of input files).
+    """
+    if any(
+        len(transformed_files) != expected_file_count
+        for transformed_files in ab_transformed_file_lists
+    ):
+        raise OutputValidationError(  # noqa: TRY003
+            "At least one or more transformed JSON file(s) are missing. "
+            f"Expecting {expected_file_count} transformed JSON file(s)."
+            "Check the transformed file directories."
+        )
 
 
 def parse_transform_details_from_extract_filename(input_file: str) -> tuple[str, ...]:

--- a/tests/test_build_ab_images.py
+++ b/tests/test_build_ab_images.py
@@ -1,12 +1,15 @@
 import os
 from unittest.mock import patch
 
+import pytest
+
 from abdiff.core.build_ab_images import (
     build_ab_images,
     build_image,
     clone_repo_and_reset_to_commit,
     docker_image_exists,
 )
+from abdiff.core.exceptions import InvalidRepositoryCommitSHAError
 from abdiff.core.utils import read_job_json
 
 
@@ -27,6 +30,24 @@ def test_build_ab_images_success(mocked_clone, job_directory, mocked_docker_clie
         "image_tag_a": "transmogrifier-example-job-1-abc123:latest",
         "image_tag_b": "transmogrifier-example-job-1-def456:latest",
     }
+
+
+@patch("abdiff.core.build_ab_images.clone_repository")
+def test_build_ab_images_invalid_commit_sha_raise_error(
+    mocked_clone, job_directory, mocked_docker_client, caplog
+):
+    caplog.set_level("DEBUG")
+    side_effect = os.makedirs(job_directory + "/clone")
+    mocked_clone.side_effect = side_effect
+    mocked_clone.return_value.reset.side_effect = KeyError
+
+    with pytest.raises(InvalidRepositoryCommitSHAError):
+        build_ab_images(
+            job_directory,
+            "invalid",
+            "def456",
+            mocked_docker_client,
+        )
 
 
 def test_docker_image_exists_returns_true(mocked_docker_client):

--- a/tests/test_run_ab_transforms.py
+++ b/tests/test_run_ab_transforms.py
@@ -56,7 +56,7 @@ def test_run_ab_transforms_success(
         )
 
 
-def test_run_ab_transforms_raise_error(
+def test_run_ab_transforms_raise_error_if_containers_failed(
     run_directory,
     transformed_directories,
     mocked_docker_client,
@@ -186,7 +186,7 @@ def test_validate_output_success():
     assert (
         validate_output(
             ab_transformed_file_lists=(["transformed/a/file1"], ["transformed/b/file2"]),
-            expected_file_count=1,
+            input_files_count=1,
         )
         is None
     )
@@ -194,7 +194,7 @@ def test_validate_output_success():
 
 def test_validate_output_error():
     with pytest.raises(OutputValidationError):
-        validate_output(ab_transformed_file_lists=([], []), expected_file_count=1)
+        validate_output(ab_transformed_file_lists=([], []), input_files_count=1)
 
 
 def test_parse_transform_details_from_extract_filename_success(input_file):

--- a/tests/test_run_ab_transforms.py
+++ b/tests/test_run_ab_transforms.py
@@ -4,13 +4,18 @@ from pathlib import Path
 
 import pytest
 
-from abdiff.core.exceptions import DockerContainerRuntimeExceededTimeoutError
+from abdiff.core.exceptions import (
+    DockerContainerRunFailedError,
+    DockerContainerRuntimeExceededTimeoutError,
+    OutputValidationError,
+)
 from abdiff.core.run_ab_transforms import (
     aggregate_logs,
     get_transformed_files,
     parse_transform_details_from_extract_filename,
     run_ab_transforms,
     run_docker_container,
+    validate_output,
     wait_for_containers,
 )
 from tests.conftest import MockedContainerRun
@@ -27,6 +32,7 @@ def test_run_ab_transforms_success(
             transformed_directories
         )
     )
+
     run_ab_transforms(
         run_directory=run_directory,
         image_tag_a="transmogrifier-example-job-1-abc123:latest",
@@ -50,6 +56,32 @@ def test_run_ab_transforms_success(
         )
 
 
+def test_run_ab_transforms_raise_error(
+    run_directory,
+    transformed_directories,
+    mocked_docker_client,
+    mocked_container_failed_runs_iter,
+    caplog,
+):
+    caplog.set_level("DEBUG")
+    mocked_docker_client.containers.run.side_effect = (
+        lambda *args, **kwargs: mocked_container_failed_runs_iter.yield_mocked_run(
+            transformed_directories
+        )
+    )
+
+    with pytest.raises(DockerContainerRunFailedError):
+        run_ab_transforms(
+            run_directory=run_directory,
+            image_tag_a="transmogrifier-example-job-1-abc123:latest",
+            image_tag_b="transmogrifier-example-job-1-def456:latest",
+            input_files=[
+                "s3://timdex-extract-dev/source/source-2024-01-01-daily-extracted-records-to-index.xml"
+            ],
+            docker_client=mocked_docker_client,
+        )
+
+
 def test_run_docker_container_success(
     mocked_docker_client,
     mocked_docker_container_and_image,
@@ -70,7 +102,7 @@ def test_run_docker_container_success(
         transformed_directory = transformed_directory_b
 
     mocked_docker_client.containers.run.side_effect = lambda *args, **kwargs: (
-        MockedContainerRun.create_transformed_files(
+        MockedContainerRun().create_transformed_files(
             transformed_directory=transformed_directory,
             container_id=mocked_docker_container.id,
             image_name=image_name,
@@ -148,6 +180,21 @@ def test_get_transformed_files_success(
             "transformed/b/source-2024-01-01-full-transformed-records-to-index.json",
         ],
     )
+
+
+def test_validate_output_success():
+    assert (
+        validate_output(
+            ab_transformed_file_lists=(["transformed/a/file1"], ["transformed/b/file2"]),
+            expected_file_count=1,
+        )
+        is None
+    )
+
+
+def test_validate_output_error():
+    with pytest.raises(OutputValidationError):
+        validate_output(ab_transformed_file_lists=([], []), expected_file_count=1)
 
 
 def test_parse_transform_details_from_extract_filename_success(input_file):


### PR DESCRIPTION
### Purpose and background context
Implement integrity checks by validating the outputs generated by core functions called in the CLI command `run-diff`. The core functions in `run-diff` this PR focuses on are: 
* `run_ab_transforms`
* `collate_ab_transforms`

These two functions have been updated to raise exceptions with the goal of stopping the flow of execution when invalid outputs are generated (as opposed to proceeding to call downstream functions that then fail as a result of invalid inputs). This will help us to better identify what causes an A/B diff run to fail.

The updates are summarized below: 
* `run_ab_transforms`
   * [Raise an error if any containers exited **with an error**.](https://github.com/MITLibraries/transmogrifier-ab-diff/pull/35/files#diff-7a49d9dbf619fca67eb5ed5ed16b6c62440a4cc6898754cd835d2b819be74ddcR117-R119) The error message will list the IDs of the failing containers, which have been added to the log file (it is now the header for each "section" of logs, where each "section"= a container run).
      * This required making updates to the function `wait_for_containers` to [check the exit code of an exited container](https://github.com/MITLibraries/transmogrifier-ab-diff/pull/35/files#diff-7a49d9dbf619fca67eb5ed5ed16b6c62440a4cc6898754cd835d2b819be74ddcR198-R206), which should be 0 if it ran successfully and 1 if an error was encountered. The function `wait_for_containers` will now return a list of IDs for failed containers; if all containers ran successfully, the function returns `None`.
      
      **Note:** The reason for doing it this way is to identify _all_ failing containers and not raise an error as soon as one container fails. It might be worth noting that if containers **are not** run in detached mode, the `docker` module would raise a `docker.errors.ContainerError` (you can read more about this error in the [docs](https://docker-py.readthedocs.io/en/stable/containers.html#container-objects)).
   * [Raise an error if the **length** of any of the transformed file _lists_ from `get_transformed_files` does not match the **length** of `input_files`.](https://github.com/MITLibraries/transmogrifier-ab-diff/pull/35/files#diff-7a49d9dbf619fca67eb5ed5ed16b6c62440a4cc6898754cd835d2b819be74ddcR259-R267)
* `collate_ab_transforms`
   * [Raise an error if the number of rows in the collated dataset is zero (i.e., empty). ](https://github.com/MITLibraries/transmogrifier-ab-diff/pull/35/files#diff-1cf5419c409425ac3b8275acb901b7c68cc1131a5b24d5846f477eb967681e55R224-R228)
   * [Raise an error if at least one of the `record_*` columns is all NA/null (i.e., empty).](https://github.com/MITLibraries/transmogrifier-ab-diff/pull/35/files#diff-1cf5419c409425ac3b8275acb901b7c68cc1131a5b24d5846f477eb967681e55R230-R236)

Additional update(s): 
* `build_ab_images`
   * [Raise an error if attempting to reset cloned repository to an invalid commit SHA. 
](https://github.com/MITLibraries/transmogrifier-ab-diff/pull/35/files#diff-a05d142e2388796ded9aed68f6d4481d3e3021603b6681fdc32d631bf81311b9R99-R105).

### How can a reviewer manually see the effects of these changes?
1. Review unit tests and confirm all tests are passing.
2. Run the following command below to see the error that gets raised when an invalid commit SHA is passed to `build_ab_images`: 
   ```shell
   pipenv run abdiff --verbose init-job -d output/test-job -m "test job" -a abc123 -b def456
   ```
   
   The screenshot below depicts the output you should see in your terminal.
   <img width="1305" alt="image" src="https://github.com/user-attachments/assets/067b7449-adb9-4b64-acf1-991f03ff1f15">

3. Clear out your `.env` file and run the following command to see what happens when `run_ab_transforms` is executed without AWS credentials (i.e., container exits with an error).
   * Run `init-job`: 
      ```shell
      pipenv run abdiff --verbose init-job \
         -d output/mvp \
         -m "test of full CLI workflow" \
         -a 395e612 \
         -b cf1024c
      ```
   * Run `run-diff`: 
      ```shell
      pipenv run abdiff --verbose run-diff \
         -d output/mvp \
         -i "s3://timdex-extract-prod-300442551476/alma/alma-2023-02-19-daily-extracted-records-to-index.xml,s3://timdex-extract-prod-300442551476/libguides/libguides-2024-04-03-full-extracted-records-to-index.xml,s3://timdex-extract-prod-300442551476/dspace/dspace-2024-10-11-daily-extracted-records-to-index.xml"
      ```

   The screenshot below depicts the output you should see in your terminal. 
   <img width="1615" alt="image" src="https://github.com/user-attachments/assets/23891ab9-ab59-4526-ba72-91ae97043e3f">

   **Note:** Trying to force raise the other errors implemented in this update would be a bit tricky, and the unit tests should suffice for this review. 🤓 

### Includes new or updated dependencies?
YES - `Pipfile.lock` previously did not include the updated set of dependencies in `Pipfile`. 

### Changes expectations for external applications?
NO

### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/TIMX-369

### Developer
- [X] All new ENV is documented in README
- [ ] All new ENV has been added to staging and production environments
- [X] All related Jira tickets are linked in commit message(s)
- [X] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer(s)
- [ ] The commit message is clear and follows our guidelines (not just this PR message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The provided documentation is sufficient for understanding any new functionality introduced
- [ ] Any manual tests have been performed **or** provided examples verified
- [ ] New dependencies are appropriate or there were no changes

