### PR TITLE
Limit parallel containers of Transmogrifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,15 @@ Compare transformed TIMDEX records from two versions (A,B) of Transmogrifier.
 
 `abdiff` is the name of the CLI application in this repository that performs an A/B test of Transmogrifier.
 
+## Development
+
+- To preview a list of available Makefile commands: `make help`
+- To install with dev dependencies: `make install`
+- To update dependencies: `make update`
+- To run unit tests: `make test`
+- To lint the repo: `make lint`
+- To run the app: `pipenv run abdiff --help`
+
 ## Concepts
 
 A **Job** in `abdiff` represents the A/B test for comparing the results from two versions of Transmogrifier.  When a job is first created, a working directory and a JSON file `job.json` with an initial set of configurations is created.
@@ -82,7 +91,9 @@ AWS_SESSION_TOKEN=# passed to Transmogrifier containers for use
 
 ```text
 WEBAPP_HOST=# host for flask webapp
-WEBAPP_PORT# port for flask webapp
+WEBAPP_PORT=# port for flask webapp
+TRANSMOGRIFIER_MAX_WORKERS=# max number of parallel Transmogrifier docker containers to run; default is 6
+TRANSMOGRIFIER_TIMEOUT=# timeout for a single Transmogrifier container; default is 5 hours
 ```
 
 ## CLI commands
@@ -146,29 +157,4 @@ Options:
   -d, --job-directory TEXT  Job directory to view in webapp.  [required]
   -h, --help                Show this message and exit.
 ```
-
-## Development
-
-- To preview a list of available Makefile commands: `make help`
-- To install with dev dependencies: `make install`
-- To update dependencies: `make update`
-- To run unit tests: `make test`
-- To lint the repo: `make lint`
-- To run the app: `pipenv run abdiff --help`
-
-## Environment Variables
-
-### Required
-
-```shell
-WORKSPACE=### Set to `dev` for local development, this will be set to `stage` and `prod` in those environments by Terraform.
-```
-
-### Optional
-
-```shell
-```
-
-
-
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ AWS_SESSION_TOKEN=# passed to Transmogrifier containers for use
 ```text
 WEBAPP_HOST=# host for flask webapp
 WEBAPP_PORT=# port for flask webapp
-TRANSMOGRIFIER_MAX_WORKERS=# max number of parallel Transmogrifier docker containers to run; default is 6
+TRANSMOGRIFIER_CONCURRENCY=# max number of parallel Transmogrifier containers to run; default is 6
 TRANSMOGRIFIER_TIMEOUT=# timeout for a single Transmogrifier container; default is 5 hours
 ```
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ AWS_SESSION_TOKEN=# passed to Transmogrifier containers for use
 ```text
 WEBAPP_HOST=# host for flask webapp
 WEBAPP_PORT=# port for flask webapp
-TRANSMOGRIFIER_CONCURRENCY=# max number of parallel Transmogrifier containers to run; default is 6
+TRANSMOGRIFIER_MAX_WORKERS=# max number of Transmogrifier containers to run in parallel; default is 6
 TRANSMOGRIFIER_TIMEOUT=# timeout for a single Transmogrifier container; default is 5 hours
 ```
 

--- a/abdiff/config.py
+++ b/abdiff/config.py
@@ -13,7 +13,7 @@ class Config:
     OPTIONAL_ENV_VARS = (
         "WEBAPP_HOST",
         "WEBAPP_PORT",
-        "TRANSMOGRIFIER_MAX_WORKERS",
+        "TRANSMOGRIFIER_CONCURRENCY",
         "TRANSMOGRIFIER_TIMEOUT",
     )
 
@@ -34,14 +34,14 @@ class Config:
         return int(port)
 
     @property
-    def transmogrifier_max_workers(self) -> int:
+    def transmogrifier_concurrency(self) -> int:
         """Maximum number of Transmogrifier containers to run in parallel."""
-        max_workers = self.TRANSMOGRIFIER_MAX_WORKERS or 6
+        max_workers = self.TRANSMOGRIFIER_CONCURRENCY or 6
         return int(max_workers)
 
     @property
     def transmogrifier_timeout(self) -> int:
-        """Timeout for a single docker container."""
+        """Timeout for a single Transmogrifier container."""
         timeout = self.TRANSMOGRIFIER_TIMEOUT or 60 * 60 * 5  # 5 hours default
         return int(timeout)
 

--- a/abdiff/config.py
+++ b/abdiff/config.py
@@ -13,6 +13,8 @@ class Config:
     OPTIONAL_ENV_VARS = (
         "WEBAPP_HOST",
         "WEBAPP_PORT",
+        "TRANSMOGRIFIER_MAX_WORKERS",
+        "TRANSMOGRIFIER_TIMEOUT",
     )
 
     def __getattr__(self, name: str) -> Any:  # noqa: ANN401
@@ -30,6 +32,18 @@ class Config:
     def webapp_port(self) -> int:
         port = self.WEBAPP_PORT or "5000"
         return int(port)
+
+    @property
+    def transmogrifier_max_workers(self) -> int:
+        """Maximum number of Transmogrifier containers to run in parallel."""
+        max_workers = self.TRANSMOGRIFIER_MAX_WORKERS or 6
+        return int(max_workers)
+
+    @property
+    def transmogrifier_timeout(self) -> int:
+        """Timeout for a single docker container."""
+        timeout = self.TRANSMOGRIFIER_TIMEOUT or 60 * 60 * 5  # 5 hours default
+        return int(timeout)
 
 
 def configure_logger(logger: logging.Logger, *, verbose: bool) -> str:

--- a/abdiff/config.py
+++ b/abdiff/config.py
@@ -13,7 +13,7 @@ class Config:
     OPTIONAL_ENV_VARS = (
         "WEBAPP_HOST",
         "WEBAPP_PORT",
-        "TRANSMOGRIFIER_CONCURRENCY",
+        "TRANSMOGRIFIER_MAX_WORKERS",
         "TRANSMOGRIFIER_TIMEOUT",
     )
 
@@ -34,9 +34,9 @@ class Config:
         return int(port)
 
     @property
-    def transmogrifier_concurrency(self) -> int:
+    def transmogrifier_max_workers(self) -> int:
         """Maximum number of Transmogrifier containers to run in parallel."""
-        max_workers = self.TRANSMOGRIFIER_CONCURRENCY or 6
+        max_workers = self.TRANSMOGRIFIER_MAX_WORKERS or 6
         return int(max_workers)
 
     @property

--- a/abdiff/core/exceptions.py
+++ b/abdiff/core/exceptions.py
@@ -3,30 +3,25 @@ class DockerContainersNotFoundError(Exception):
         super().__init__(f"No Docker containers were found with label run='{run_id}'.")
 
 
-class DockerContainerRuntimeExceededTimeoutError(Exception):
-    def __init__(self, containers: list, timeout: int) -> None:
-        self.containers = containers
+class DockerContainerTimeoutError(Exception):
+    def __init__(self, container_id: str | None, timeout: int) -> None:
+        self.container_id = container_id
         self.timeout = timeout
         super().__init__(self.get_formatted_message())
 
     def get_formatted_message(self) -> str:
-        container_ids = [container.id for container in self.containers]
-        return (
-            f"Timeout of {self.timeout} seconds exceeded."
-            f"{len(container_ids)} container(s) is/are still running:"
-            f"{container_ids}."
-        )
+        return f"Container {self.container_id} exceed timeout of {self.timeout} seconds."
 
 
 # core function errors
-class DockerContainerRunFailedError(Exception):
-    def __init__(self, containers: list) -> None:
-        self.containers = containers
+class DockerContainerRuntimeError(Exception):
+    def __init__(self, container_id: str) -> None:
+        self.container_id = container_id
         super().__init__(self.get_formatted_message())
 
     def get_formatted_message(self) -> str:
         return (
-            f"The following Docker containers exited with an error: {self.containers}. "
+            f"Container {self.container_id} did not exit cleanly. "
             "Check the logs in transformed/logs.txt to identify the error."
         )
 

--- a/abdiff/core/run_ab_transforms.py
+++ b/abdiff/core/run_ab_transforms.py
@@ -45,7 +45,8 @@ def run_ab_transforms(
         7. Return a tuple containing two lists representing all A and B transformed files.
 
     Parallelization is handled by invoking the Docker containers via threads, limited by
-    the ThreadPoolExecutor.max_workers argument.
+    the ThreadPoolExecutor.max_workers argument.  Each thread invokes a detached Docker
+    container and manages its lifecycle until completion.
 
     Args:
         run_directory (str): Run directory.
@@ -136,7 +137,7 @@ def run_all_docker_containers(
     """
     tasks = []
 
-    with ThreadPoolExecutor(max_workers=CONFIG.transmogrifier_concurrency) as executor:
+    with ThreadPoolExecutor(max_workers=CONFIG.transmogrifier_max_workers) as executor:
         for input_file in input_files:
             source, output_file = parse_transform_details_from_extract_filename(
                 input_file

--- a/abdiff/core/run_ab_transforms.py
+++ b/abdiff/core/run_ab_transforms.py
@@ -136,7 +136,7 @@ def run_all_docker_containers(
     """
     tasks = []
 
-    with ThreadPoolExecutor(max_workers=CONFIG.transmogrifier_max_workers) as executor:
+    with ThreadPoolExecutor(max_workers=CONFIG.transmogrifier_concurrency) as executor:
         for input_file in input_files:
             source, output_file = parse_transform_details_from_extract_filename(
                 input_file

--- a/abdiff/core/run_ab_transforms.py
+++ b/abdiff/core/run_ab_transforms.py
@@ -5,6 +5,7 @@ import logging
 import os
 import re
 import time
+from concurrent.futures import Future, ThreadPoolExecutor
 from datetime import timedelta
 from pathlib import Path
 from time import perf_counter
@@ -14,8 +15,8 @@ from docker.models.containers import Container
 
 from abdiff.config import Config
 from abdiff.core.exceptions import (
-    DockerContainerRunFailedError,
-    DockerContainerRuntimeExceededTimeoutError,
+    DockerContainerRuntimeError,
+    DockerContainerTimeoutError,
     OutputValidationError,
 )
 from abdiff.core.utils import create_subdirectories, update_or_create_run_json
@@ -31,22 +32,20 @@ def run_ab_transforms(
     image_tag_b: str,
     input_files: list[str],
     docker_client: docker.client.DockerClient | None = None,
-    timeout: int = 600,
 ) -> tuple[list[str], ...]:
     """Run Docker containers with versioned images of Transmogrifier.
 
-    The following steps are perfomed in sequential order:
+    The following steps are performed in sequential order:
         1. Directories are created to capture the transformed files.
-        2. For all input files, an A and B version of Transmogrifier is run
-           via detached Docker containers, resulting in all containers
-           running in parallel.
+        2. For all input files, an A and B version of Transmogrifier is run.
         3. Wait for all containers to complete.
         4. Aggregate logs from all containers.
-        5. If any containers exit, raise an error listing the IDs for failed
-           containers.
-        6. Validate the number of files in the A/B transformed file directories.
-        7. Update run.json with lists describing input and transformed files.
-        8. Return a tuple containing two lists representing all A and B transformed files.
+        5. Validate output.
+        6. Update run.json with lists describing input and transformed files.
+        7. Return a tuple containing two lists representing all A and B transformed files.
+
+    Parallelization is handled by invoking the Docker containers via threads, limited by
+    the ThreadPoolExecutor.max_workers argument.
 
     Args:
         run_directory (str): Run directory.
@@ -56,8 +55,6 @@ def run_ab_transforms(
             URIs for input files on S3 are accepted.
         docker_client (docker.client.DockerClient | None, optional): Docker client.
             Defaults to None.
-        timeout (int, optional): Timeout for Docker container runs. An error is raised
-            if any Docker container runs exceed the timeout. Defaults to 180 secondss.
 
     Returns:
         tuple[list[str], ...]: A tuple containing two lists, where each list contains
@@ -78,9 +75,9 @@ def run_ab_transforms(
     """
     start_time = perf_counter()
 
+    # initialize environment
     if not docker_client:
         docker_client = docker.from_env()
-
     transformed_directory_a, transformed_directory_b = create_subdirectories(
         base_directory=run_directory, subdirectories=["transformed/a", "transformed/b"]
     )
@@ -88,51 +85,75 @@ def run_ab_transforms(
         "Transformed directories created: "
         f"{[transformed_directory_a, transformed_directory_b]}"
     )
-
     run_configs = [
         (image_tag_a, transformed_directory_a),
         (image_tag_b, transformed_directory_b),
     ]
 
-    containers = []
-    for input_file in input_files:
-        source, output_file = parse_transform_details_from_extract_filename(input_file)
-        for docker_image, transformed_directory in run_configs:
-            container = run_docker_container(
-                docker_image,
-                transformed_directory,
-                source,
-                input_file,
-                output_file,
-                docker_client,
-            )
-            containers.append(container)
+    # run containers and collect results
+    futures = run_all_docker_containers(docker_client, input_files, run_configs)
+    containers, exceptions = collect_container_results(futures)
+    logger.info(
+        f"Successful containers: {len(containers)}, failed containers: {len(exceptions)}"
+    )
 
-    failed_containers = wait_for_containers(containers, timeout)
-    logger.info(f"All {len(containers)} containers have exited.")
-
+    # process results
     log_file = aggregate_logs(run_directory, containers)
     logger.info(f"Log file created: {log_file}")
-
-    # errors from failed containers are accessible via aggregated logs
-    if failed_containers:
-        raise DockerContainerRunFailedError(failed_containers)
-
+    if exceptions:
+        raise RuntimeError(  # noqa: TRY003
+            f"{len(exceptions)} / {len(containers) + len(exceptions)} containers failed "
+            "to complete successfully."
+        )
     ab_transformed_file_lists = get_transformed_files(run_directory)
-
     validate_output(ab_transformed_file_lists, len(input_files))
 
+    # write and return results
     run_data = {
         "input_files": input_files,
         "transformed_files": ab_transformed_file_lists,
     }
     update_or_create_run_json(run_directory, run_data)
-
     elapsed_time = perf_counter() - start_time
     logger.info(
         "Total time to complete process: %s", str(timedelta(seconds=elapsed_time))
     )
     return ab_transformed_file_lists
+
+
+def run_all_docker_containers(
+    docker_client: docker.client.DockerClient,
+    input_files: list[str],
+    run_configs: list[tuple],
+) -> list[Future]:
+    """Invoke Docker containers to run in parallel via threads.
+
+    By default, when ThreadPoolExecutor is invoked via a context manager it will wait for
+    all tasks to complete before exiting the context manager.  While each container is run
+    in a detached mode, the function run_docker_container() waits for the container to
+    exit making it effectively blocking.  The net result: this function will run all
+    containers to completion, returning the completed tasks (Future objects) as a list.
+    """
+    tasks = []
+
+    with ThreadPoolExecutor(max_workers=CONFIG.transmogrifier_max_workers) as executor:
+        for input_file in input_files:
+            source, output_file = parse_transform_details_from_extract_filename(
+                input_file
+            )
+            for docker_image, transformed_directory in run_configs:
+                args = (
+                    docker_image,
+                    transformed_directory,
+                    source,
+                    input_file,
+                    output_file,
+                    docker_client,
+                )
+                tasks.append(executor.submit(run_docker_container, *args))
+
+    logger.info(f"All {len(tasks)} containers have exited.")
+    return tasks
 
 
 def run_docker_container(
@@ -142,8 +163,13 @@ def run_docker_container(
     input_file: str,
     output_file: str,
     docker_client: docker.client.DockerClient,
+    timeout: int = CONFIG.transmogrifier_timeout,
 ) -> Container:
-    """Run transmogrifier via Docker container to transform input file."""
+    """Run Transmogrifier via Docker container to transform input file.
+
+    The container is run in a detached state to capture a container handle for later use
+    but this function waits for the container to exit before returning.
+    """
     container = docker_client.containers.run(
         docker_image,
         command=[
@@ -168,47 +194,47 @@ def run_docker_container(
         f"Container '{container.id}' (Docker image: {docker_image}) "
         f"RUNNING transform for '{source}' input_file: {input_file}."
     )
+
+    start_time = perf_counter()
+    while True:
+        time.sleep(0.5)
+        container.reload()
+        if container.status == "exited":
+            logger.info(f"Container {container.id} exited.")
+            break
+
+        if time.perf_counter() - start_time > timeout:
+            logger.error(f"Container {container.id} timed out after {timeout} seconds")
+            container.stop()
+            raise DockerContainerTimeoutError(container_id=container.id, timeout=timeout)
+
     return container
 
 
-def wait_for_containers(
-    containers: list[Container], timeout: int = 180
-) -> None | list[str]:
-    """Given a list of running containers, wait until all containers exit.
+def collect_container_results(
+    futures: list[Future],
+) -> tuple[list[Container], list[Exception]]:
+    """Collect results of container executions.
 
-    If there are any containers that exited with an error, a list of IDs
-    for failed containers is returned. For more information regarding the
-    specific cause of the error, consult the logs.
+    Returns a tuple of (Containers (success), Exceptions (failure)) from all executions.
     """
-    exited_containers: list[str] = []
-    failed_containers: list[str] = []
-    start_time = time.time()
-    while len(exited_containers) < len(containers):
-        running_containers = [
-            container for container in containers if container.id not in exited_containers
-        ]
-        if time.time() - start_time >= timeout:
-            raise DockerContainerRuntimeExceededTimeoutError(
-                containers=running_containers, timeout=timeout
-            )
-        for container in running_containers:
-            container.reload()
-            if container.status == "exited":
-                logger.info(f"Container {container.id} exited.")
-                exited_containers.append(container.id)  # type: ignore[arg-type]
-                if (exit_code := container.attrs["State"]["ExitCode"]) == 0:
-                    logger.info(f"Container {container.id} ran successfully.")
-                else:
-                    logger.error(
-                        f"Container {container.id} exited with an error: {exit_code}. "
-                        "Check logs for details."
-                    )
-                    failed_containers.append(container.id)  # type: ignore[arg-type]
-        time.sleep(0.25)
+    successes = []
+    failures = []
+    for future in futures:
 
-    if any(failed_containers):
-        return failed_containers
-    return None
+        try:
+            container = future.result()
+        except Exception as e:  # noqa: BLE001; capture any exception
+            failures.append(e)
+            continue
+
+        if container.attrs["State"]["ExitCode"] == 0:
+            successes.append(container)
+        else:
+            failures.append(DockerContainerRuntimeError(container.id))
+
+    logger.info(f"Completed: {len(successes)} successes, {len(failures)} failures")
+    return successes, failures
 
 
 def aggregate_logs(run_directory: str, containers: list[Container]) -> str:
@@ -264,7 +290,7 @@ def validate_output(
     ):
         raise OutputValidationError(  # noqa: TRY003
             "At least one or more transformed JSON file(s) are missing. "
-            f"Expecting {input_files_count} transformed JSON file(s)."
+            f"Expecting {input_files_count} transformed JSON file(s) per A/B version. "
             "Check the transformed file directories."
         )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -128,11 +128,12 @@ class MockedContainerRun:
 
 class MockedFutureSuccess(Future):
 
-    def __init__(self, container: Container | None = None):
+    def __init__(self, container: Container, exception: Exception | None = None):
         self.container = container
+        self.exception = exception
 
     def result(self, timeout=None):  # noqa: ARG002
-        return self.container
+        return self.container, self.exception
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,10 +2,10 @@
 
 import json
 import os
-import random
 import shutil
 import time
 import warnings
+from concurrent.futures import Future
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -35,6 +35,8 @@ class Container:
         self.id = id
         self.labels = labels
         self.status = "created"
+        self.run_duration = 0.5
+        self.start_time = time.time()
 
         if attrs:
             self.attrs = attrs
@@ -42,13 +44,23 @@ class Container:
             self.attrs = {"State": {"ExitCode": 0}}
 
     def reload(self):
+        """Simulate reload the status of a Docker container.
+
+        Checking if a detached Container has completed is performed by running its
+        reload method.  This waits 0.1s, then only resolves to 'exited' if the container
+        instance has existed longer than self.run_duration, thereby simulating a total
+        running time of X seconds.
+        """
         time.sleep(0.1)
-        if random.randint(0, 100) > 50:  # noqa: PLR2004, S311
+        if time.time() - self.start_time >= self.run_duration:
             self.status = "exited"
 
     def logs(self):
         with open("tests/fixtures/transmogrifier-logs.txt", "rb") as file:
             return file.read()
+
+    def stop(self):
+        pass
 
 
 class MockedContainerRun:
@@ -112,6 +124,15 @@ class MockedContainerRun:
                 "input_file": "s3://timdex-extract-dev/source/source-2024-01-01-daily-extracted-records-to-index.xml",
             },
         )
+
+
+class MockedFutureSuccess(Future):
+
+    def __init__(self, container: Container | None = None):
+        self.container = container
+
+    def result(self, timeout=None):  # noqa: ARG002
+        return self.container
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
### Purpose and background context

As outlined in [TIMX-356](https://mitlibraries.atlassian.net/browse/TIMX-356), we needed a way to limit how many Transmogrifier containers were running in parallel to avoid overhwleming system resources.

When @jonavellecuerdo had originally worked on the `run_ab_transforms` module, I believe it was floated to use threads.  The decision to just fire off detached Docker containers was considerably simpler, and supported getting to an MVP.  In a way, this work is revisiting some original designs.

Primary changes:
  * this works builds on the additional error handling and validation from [PR-35](https://github.com/MITLibraries/transmogrifier-ab-diff/pull/35)
    * this introduced the idea of "failed containers" and this code just reworks that slightly for threads where a completed thread either returns a `Container` or an `Exception`
  * broke out function for invoking containers via threads, `run_all_docker_containers()`
  * function `run_docker_container()` (singular) now **waits** for the container to exit
  * method for collecting their results, `collect_container_results()`
    * very similar to `wait_for_containers()`, but that name wasn't quite accurate anymore given the containers / threads were already complete by then; it's more about collecting the results of those completed threads




### How can a reviewer manually see the effects of these changes?

**1- Set production AWS credentials in `.env`**

**2- Create a new job:**
```shell
pipenv run abdiff --verbose init-job \
-d output/jobs/parallel \
-a 008e20c -b 395e612
```

**3- Run diff with ~62 input files (NOTE: _very_ long CLI command string.  See [TIMX-379]**(https://mitlibraries.atlassian.net/browse/TIMX-379) for possible improvements):
```shell
pipenv run abdiff --verbose run-diff \
-d output/jobs/parallel \
-i s3://timdex-extract-prod-300442551476/libguides/libguides-2024-08-15-daily-extracted-records-to-index.xml,s3://timdex-extract-prod-300442551476/libguides/libguides-2024-08-16-daily-extracted-records-to-index.xml,s3://timdex-extract-prod-300442551476/libguides/libguides-2024-08-17-daily-extracted-records-to-index.xml,s3://timdex-extract-prod-300442551476/libguides/libguides-2024-08-19-daily-extracted-records-to-index.xml,s3://timdex-extract-prod-300442551476/libguides/libguides-2024-08-20-daily-extracted-records-to-index.xml,s3://timdex-extract-prod-300442551476/libguides/libguides-2024-08-21-daily-extracted-records-to-index.xml,s3://timdex-extract-prod-300442551476/libguides/libguides-2024-08-22-daily-extracted-records-to-index.xml,s3://timdex-extract-prod-300442551476/libguides/libguides-2024-08-23-daily-extracted-records-to-index.xml,s3://timdex-extract-prod-300442551476/libguides/libguides-2024-08-24-daily-extracted-records-to-index.xml,s3://timdex-extract-prod-300442551476/libguides/libguides-2024-08-25-daily-extracted-records-to-index.xml,s3://timdex-extract-prod-300442551476/libguides/libguides-2024-08-26-daily-extracted-records-to-index.xml,s3://timdex-extract-prod-300442551476/libguides/libguides-2024-08-27-daily-extracted-records-to-index.xml,s3://timdex-extract-prod-300442551476/libguides/libguides-2024-08-28-daily-extracted-records-to-index.xml,s3://timdex-extract-prod-300442551476/libguides/libguides-2024-08-29-daily-extracted-records-to-index.xml,s3://timdex-extract-prod-300442551476/libguides/libguides-2024-08-30-daily-extracted-records-to-index.xml,s3://timdex-extract-prod-300442551476/libguides/libguides-2024-08-31-daily-extracted-records-to-index.xml,s3://timdex-extract-prod-300442551476/libguides/libguides-2024-09-03-daily-extracted-records-to-index.xml,s3://timdex-extract-prod-300442551476/libguides/libguides-2024-09-04-daily-extracted-records-to-index.xml,s3://timdex-extract-prod-300442551476/libguides/libguides-2024-09-05-daily-extracted-records-to-index.xml,s3://timdex-extract-prod-300442551476/libguides/libguides-2024-09-06-daily-extracted-records-to-index.xml,s3://timdex-extract-prod-300442551476/libguides/libguides-2024-09-07-daily-extracted-records-to-index.xml,s3://timdex-extract-prod-300442551476/libguides/libguides-2024-09-08-daily-extracted-records-to-index.xml,s3://timdex-extract-prod-300442551476/libguides/libguides-2024-09-09-daily-extracted-records-to-index.xml,s3://timdex-extract-prod-300442551476/libguides/libguides-2024-09-10-daily-extracted-records-to-index.xml,s3://timdex-extract-prod-300442551476/libguides/libguides-2024-09-11-daily-extracted-records-to-index.xml,s3://timdex-extract-prod-300442551476/libguides/libguides-2024-09-12-daily-extracted-records-to-index.xml,s3://timdex-extract-prod-300442551476/libguides/libguides-2024-09-13-daily-extracted-records-to-index.xml,s3://timdex-extract-prod-300442551476/libguides/libguides-2024-09-14-daily-extracted-records-to-index.xml,s3://timdex-extract-prod-300442551476/libguides/libguides-2024-09-16-daily-extracted-records-to-index.xml,s3://timdex-extract-prod-300442551476/libguides/libguides-2024-09-17-daily-extracted-records-to-index.xml,s3://timdex-extract-prod-300442551476/libguides/libguides-2024-09-18-daily-extracted-records-to-index.xml,s3://timdex-extract-prod-300442551476/libguides/libguides-2024-09-19-daily-extracted-records-to-index.xml,s3://timdex-extract-prod-300442551476/libguides/libguides-2024-09-20-daily-extracted-records-to-index.xml,s3://timdex-extract-prod-300442551476/libguides/libguides-2024-09-21-daily-extracted-records-to-index.xml,s3://timdex-extract-prod-300442551476/libguides/libguides-2024-09-22-daily-extracted-records-to-index.xml,s3://timdex-extract-prod-300442551476/libguides/libguides-2024-09-23-daily-extracted-records-to-index.xml,s3://timdex-extract-prod-300442551476/libguides/libguides-2024-09-24-daily-extracted-records-to-index.xml,s3://timdex-extract-prod-300442551476/libguides/libguides-2024-09-25-daily-extracted-records-to-index.xml,s3://timdex-extract-prod-300442551476/libguides/libguides-2024-09-26-daily-extracted-records-to-index.xml,s3://timdex-extract-prod-300442551476/libguides/libguides-2024-09-27-daily-extracted-records-to-index.xml,s3://timdex-extract-prod-300442551476/libguides/libguides-2024-09-28-daily-extracted-records-to-index.xml,s3://timdex-extract-prod-300442551476/libguides/libguides-2024-09-29-daily-extracted-records-to-index.xml,s3://timdex-extract-prod-300442551476/libguides/libguides-2024-09-30-daily-extracted-records-to-index.xml,s3://timdex-extract-prod-300442551476/libguides/libguides-2024-10-01-daily-extracted-records-to-index.xml,s3://timdex-extract-prod-300442551476/libguides/libguides-2024-10-02-daily-extracted-records-to-index.xml,s3://timdex-extract-prod-300442551476/libguides/libguides-2024-10-03-daily-extracted-records-to-index.xml,s3://timdex-extract-prod-300442551476/libguides/libguides-2024-10-04-daily-extracted-records-to-index.xml,s3://timdex-extract-prod-300442551476/libguides/libguides-2024-10-05-daily-extracted-records-to-index.xml,s3://timdex-extract-prod-300442551476/libguides/libguides-2024-10-07-daily-extracted-records-to-index.xml,s3://timdex-extract-prod-300442551476/libguides/libguides-2024-10-08-daily-extracted-records-to-index.xml,s3://timdex-extract-prod-300442551476/libguides/libguides-2024-10-09-daily-extracted-records-to-index.xml,s3://timdex-extract-prod-300442551476/libguides/libguides-2024-10-10-daily-extracted-records-to-index.xml,s3://timdex-extract-prod-300442551476/libguides/libguides-2024-10-11-daily-extracted-records-to-index.xml,s3://timdex-extract-prod-300442551476/libguides/libguides-2024-10-12-daily-extracted-records-to-index.xml,s3://timdex-extract-prod-300442551476/libguides/libguides-2024-10-13-daily-extracted-records-to-index.xml,s3://timdex-extract-prod-300442551476/libguides/libguides-2024-10-15-daily-extracted-records-to-index.xml,s3://timdex-extract-prod-300442551476/libguides/libguides-2024-10-16-daily-extracted-records-to-index.xml,s3://timdex-extract-prod-300442551476/libguides/libguides-2024-10-17-daily-extracted-records-to-index.xml,s3://timdex-extract-prod-300442551476/libguides/libguides-2024-10-18-daily-extracted-records-to-index.xml,s3://timdex-extract-prod-300442551476/libguides/libguides-2024-10-19-daily-extracted-records-to-index.xml,s3://timdex-extract-prod-300442551476/libguides/libguides-2024-10-21-daily-extracted-records-to-index.xml,s3://timdex-extract-prod-300442551476/libguides/libguides-2024-10-22-daily-extracted-records-to-index.xml
```

**Additional testing:**
- env var `TRANSMOGRIFIER_MAX_WORKERS`
  - in another terminal, run `docker stats` to see a live representation of parallel containers
  - set value of "1" and note that only one container at a time
  - set value of "8" and watch it consume a high, but reasonable amount of resources; runs quicker
- env var `TRANSMOGRIFIER_TIMEOUT`
  - set to "1" (one second) and note should be lots of timeouts

### Includes new or updated dependencies?
YES | NO

### Changes expectations for external applications?
YES | NO

### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/TIMX-356

### Developer
- [ ] All new ENV is documented in README
- [ ] All new ENV has been added to staging and production environments
- [ ] All related Jira tickets are linked in commit message(s)
- [ ] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer(s)
- [ ] The commit message is clear and follows our guidelines (not just this PR message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The provided documentation is sufficient for understanding any new functionality introduced
- [ ] Any manual tests have been performed **or** provided examples verified
- [ ] New dependencies are appropriate or there were no changes



[TIMX-356]: https://mitlibraries.atlassian.net/browse/TIMX-356?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TIMX-379]: https://mitlibraries.atlassian.net/browse/TIMX-379?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ