### PR TITLE
Add utility function to parse details from S3 URIs and filenames

### DIFF
--- a/abdiff/core/run_ab_transforms.py
+++ b/abdiff/core/run_ab_transforms.py
@@ -3,7 +3,6 @@
 import glob
 import logging
 import os
-import re
 import time
 from concurrent.futures import Future, ThreadPoolExecutor
 from datetime import timedelta
@@ -19,7 +18,11 @@ from abdiff.core.exceptions import (
     DockerContainerTimeoutError,
     OutputValidationError,
 )
-from abdiff.core.utils import create_subdirectories, update_or_create_run_json
+from abdiff.core.utils import (
+    create_subdirectories,
+    parse_timdex_filename,
+    update_or_create_run_json,
+)
 
 CONFIG = Config()
 
@@ -139,16 +142,14 @@ def run_all_docker_containers(
 
     with ThreadPoolExecutor(max_workers=CONFIG.transmogrifier_max_workers) as executor:
         for input_file in input_files:
-            source, output_file = parse_transform_details_from_extract_filename(
-                input_file
-            )
+            filename_details = parse_timdex_filename(input_file)
             for docker_image, transformed_directory in run_configs:
                 args = (
                     docker_image,
                     transformed_directory,
-                    source,
+                    str(filename_details["source"]),
                     input_file,
-                    output_file,
+                    get_transformed_filename(filename_details),
                     docker_client,
                 )
                 tasks.append(executor.submit(run_docker_container, *args))
@@ -310,22 +311,13 @@ def validate_output(
         )
 
 
-def parse_transform_details_from_extract_filename(input_file: str) -> tuple[str, ...]:
-    """Parse transform details from extract filename.
-
-    Namely, the source and the output filename are parsed from the extract
-    filename. These variables are required by the transform command.
-    """
-    extract_filename = input_file.split("/")[-1]
-    match_result = re.match(
-        r"^([\w\-]+?)-(\d{4}-\d{2}-\d{2})-(\w+)-extracted-records-to-index(?:_(\d+))?\.\w+$",
-        extract_filename,
+def get_transformed_filename(filename_details: dict) -> str:
+    """Get transformed filename using extract filename details."""
+    filename_details.update(
+        stage="transformed",
+        index=f"_{sequence}" if (sequence := filename_details["index"]) else "",
     )
-    if not match_result:
-        raise ValueError(  # noqa: TRY003
-            f"Extract filename is invalid: {extract_filename}."
-        )
-    source, date, cadence, sequence = match_result.groups()
-    sequence_suffix = f"_{sequence}" if sequence else ""
-    output_filename = f"{source}-{date}-{cadence}-transformed-records-to-index{sequence_suffix}.json"  # noqa: E501
-    return source, output_filename
+    output_filename = (
+        "{source}-{date}-{cadence}-{stage}-records-to-index{index}.{file_type}"
+    )
+    return output_filename.format(**filename_details)

--- a/abdiff/core/run_ab_transforms.py
+++ b/abdiff/core/run_ab_transforms.py
@@ -318,6 +318,13 @@ def get_transformed_filename(filename_details: dict) -> str:
         index=f"_{sequence}" if (sequence := filename_details["index"]) else "",
     )
     output_filename = (
-        "{source}-{date}-{cadence}-{stage}-records-to-index{index}.{file_type}"
+        "{source}-{run_date}-{run_type}-{stage}-records-to-index{index}.{file_type}"
     )
-    return output_filename.format(**filename_details)
+    return output_filename.format(
+        source=filename_details["source"],
+        run_date=filename_details["run-date"],
+        run_type=filename_details["run-type"],
+        stage=filename_details["stage"],
+        index=filename_details["index"],
+        file_type=filename_details["file_type"],
+    )

--- a/abdiff/core/utils.py
+++ b/abdiff/core/utils.py
@@ -88,7 +88,7 @@ def parse_timdex_filename(s3_uri_or_filename: str) -> dict[str, str | None]:
         filename,
     )
 
-    keys = ["source", "date", "cadence", "stage", "action", "index", "file_type"]
+    keys = ["source", "run-date", "run-type", "stage", "action", "index", "file_type"]
     if not match_result:
         raise ValueError(  # noqa: TRY003
             f"Provided S3 URI and filename is invalid: {filename}."

--- a/abdiff/core/utils.py
+++ b/abdiff/core/utils.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import re
 from collections.abc import Iterable
 from pathlib import Path
 
@@ -76,6 +77,29 @@ def create_subdirectories(
 def load_dataset(base_dir: str | Path) -> ds.Dataset:
     """Standardized way of reading of parquet datasets in application."""
     return ds.dataset(base_dir, partitioning="hive")
+
+
+def parse_timdex_filename(s3_uri_or_filename: str) -> dict[str, str | None]:
+    """Parse details from filename."""
+    filename = s3_uri_or_filename.split("/")[-1]
+
+    match_result = re.match(
+        r"^([\w\-]+?)-(\d{4}-\d{2}-\d{2})-(\w+)-(\w+)-records-to-(.+?)(?:_(\d+))?\.(\w+)$",
+        filename,
+    )
+
+    keys = ["source", "date", "cadence", "stage", "action", "index", "file_type"]
+    if not match_result:
+        raise ValueError(  # noqa: TRY003
+            f"Provided S3 URI and filename is invalid: {filename}."
+        )
+
+    try:
+        return dict(zip(keys, match_result.groups(), strict=True))
+    except ValueError as exception:
+        raise ValueError(  # noqa: TRY003
+            f"Provided S3 URI and filename is invalid: {filename}."
+        ) from exception
 
 
 def write_to_dataset(

--- a/tests/test_run_ab_transforms.py
+++ b/tests/test_run_ab_transforms.py
@@ -12,12 +12,13 @@ from abdiff.core.exceptions import (
 from abdiff.core.run_ab_transforms import (
     aggregate_logs,
     collect_container_results,
+    get_transformed_filename,
     get_transformed_files,
-    parse_transform_details_from_extract_filename,
     run_ab_transforms,
     run_docker_container,
     validate_output,
 )
+from abdiff.core.utils import parse_timdex_filename
 from tests.conftest import MockedContainerRun, MockedFutureSuccess
 
 
@@ -113,13 +114,13 @@ def test_run_docker_container_success(
     )
 
     input_file = "s3://timdex-extract-dev/source/source-2024-01-01-daily-extracted-records-to-index.xml"
-    source, output_file = parse_transform_details_from_extract_filename(input_file)
-    container, exception = run_docker_container(
+    filename_details = parse_timdex_filename(input_file)
+    container, _ = run_docker_container(
         docker_image=image_name,
         transformed_directory=transformed_directory,
-        source=source,
+        source=filename_details["source"],
         input_file=input_file,
-        output_file=output_file,
+        output_file=get_transformed_filename(filename_details),
         docker_client=mocked_docker_client,
     )
     assert container.id == mocked_docker_container.id
@@ -180,25 +181,21 @@ def test_validate_output_error():
         validate_output(ab_transformed_file_lists=([], []), input_files_count=1)
 
 
-def test_parse_transform_details_from_extract_filename_success(input_file):
-    source, output_file = parse_transform_details_from_extract_filename(input_file)
-    assert source == "source"
-    assert output_file == "source-2024-01-01-full-transformed-records-to-index.json"
-
-
-def test_parse_transform_details_from_extract_filename_if_sequenced_success():
-    input_file = "s3://timdex-extract-dev/source/source-2024-01-01-full-extracted-records-to-index_01.xml"
-    source, output_filename = parse_transform_details_from_extract_filename(input_file)
-    assert source == "source"
+def test_get_output_filename_success():
     assert (
-        output_filename == "source-2024-01-01-full-transformed-records-to-index_01.json"
+        get_transformed_filename(
+            {
+                "source": "source",
+                "date": "2024-01-01",
+                "cadence": "full",
+                "stage": "extracted",
+                "action": "index",
+                "index": None,
+                "file_type": "xml",
+            }
+        )
+        == "source-2024-01-01-full-transformed-records-to-index.xml"
     )
-
-
-def test_parse_transform_details_from_extract_filename_raise_error():
-    input_file = "s3://timdex-extract-dev/source/-2024-01-01-full-extracted-records-to-index_01.xml"
-    with pytest.raises(ValueError, match="Extract filename is invalid"):
-        parse_transform_details_from_extract_filename(input_file)
 
 
 def test_run_docker_container_timeout_triggered(
@@ -207,7 +204,7 @@ def test_run_docker_container_timeout_triggered(
     mocked_docker_client.containers.run.return_value = mocked_docker_container_a
     mocked_docker_container_a.run_duration = 2
     timeout = 1
-    container, exception = run_docker_container(
+    _, exception = run_docker_container(
         "abc123",
         "abc",
         "alma",
@@ -225,7 +222,7 @@ def test_run_docker_container_timeout_not_triggered(
     mocked_docker_client.containers.run.return_value = mocked_docker_container_a
     mocked_docker_container_a.run_duration = 2
     timeout = 3
-    container, exception = run_docker_container(
+    container, _ = run_docker_container(
         "abc123",
         "abc",
         "alma",
@@ -288,3 +285,20 @@ def test_collect_containers_return_containers_and_exceptions(
     assert len(containers) == 2
     assert len(exceptions) == 1
     assert exceptions[0] == mocked_exception
+
+
+def test_get_output_filename_indexed_success():
+    assert (
+        get_transformed_filename(
+            {
+                "source": "source",
+                "date": "2024-01-01",
+                "cadence": "full",
+                "stage": "extracted",
+                "action": "index",
+                "index": "01",
+                "file_type": "xml",
+            }
+        )
+        == "source-2024-01-01-full-transformed-records-to-index_01.xml"
+    )

--- a/tests/test_run_ab_transforms.py
+++ b/tests/test_run_ab_transforms.py
@@ -186,8 +186,8 @@ def test_get_output_filename_success():
         get_transformed_filename(
             {
                 "source": "source",
-                "date": "2024-01-01",
-                "cadence": "full",
+                "run-date": "2024-01-01",
+                "run-type": "full",
                 "stage": "extracted",
                 "action": "index",
                 "index": None,
@@ -292,8 +292,8 @@ def test_get_output_filename_indexed_success():
         get_transformed_filename(
             {
                 "source": "source",
-                "date": "2024-01-01",
-                "cadence": "full",
+                "run-date": "2024-01-01",
+                "run-type": "full",
                 "stage": "extracted",
                 "action": "index",
                 "index": "01",

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,6 +8,7 @@ import pytest
 from abdiff.core import init_job
 from abdiff.core.utils import (
     create_subdirectories,
+    parse_timdex_filename,
     read_job_json,
     update_or_create_job_json,
     write_to_dataset,
@@ -54,6 +55,53 @@ def test_create_sub_directories_success(tmp_path):
     )
     assert os.path.exists(subdirectory_a)
     assert os.path.exists(subdirectory_b)
+
+
+def test_parse_timdex_filename_s3_uri_success():
+    assert parse_timdex_filename(
+        "s3://timdex-extract-dev/source/source-2024-01-01-full-extracted-records-to-index.xml"
+    ) == {
+        "source": "source",
+        "date": "2024-01-01",
+        "cadence": "full",
+        "stage": "extracted",
+        "action": "index",
+        "index": None,
+        "file_type": "xml",
+    }
+
+
+def test_parse_timdex_filename_indexed_s3_uri_success():
+    assert parse_timdex_filename(
+        "s3://timdex-extract-dev/source/source-2024-01-01-full-extracted-records-to-index_01.xml"
+    ) == {
+        "source": "source",
+        "date": "2024-01-01",
+        "cadence": "full",
+        "stage": "extracted",
+        "action": "index",
+        "index": "01",
+        "file_type": "xml",
+    }
+
+
+def test_parse_timdex_filename_filename_success():
+    assert parse_timdex_filename(
+        "source-2024-01-01-full-extracted-records-to-index.xml"
+    ) == {
+        "source": "source",
+        "date": "2024-01-01",
+        "cadence": "full",
+        "stage": "extracted",
+        "action": "index",
+        "index": None,
+        "file_type": "xml",
+    }
+
+
+def test_parse_timdex_filename_raise_error_if_invalid_filename():
+    with pytest.raises(ValueError, match="Provided S3 URI and filename is invalid."):
+        parse_timdex_filename(s3_uri_or_filename="invalid")
 
 
 def test_write_to_dataset_success(tmp_path):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -62,8 +62,8 @@ def test_parse_timdex_filename_s3_uri_success():
         "s3://timdex-extract-dev/source/source-2024-01-01-full-extracted-records-to-index.xml"
     ) == {
         "source": "source",
-        "date": "2024-01-01",
-        "cadence": "full",
+        "run-date": "2024-01-01",
+        "run-type": "full",
         "stage": "extracted",
         "action": "index",
         "index": None,
@@ -76,8 +76,8 @@ def test_parse_timdex_filename_indexed_s3_uri_success():
         "s3://timdex-extract-dev/source/source-2024-01-01-full-extracted-records-to-index_01.xml"
     ) == {
         "source": "source",
-        "date": "2024-01-01",
-        "cadence": "full",
+        "run-date": "2024-01-01",
+        "run-type": "full",
         "stage": "extracted",
         "action": "index",
         "index": "01",
@@ -90,8 +90,8 @@ def test_parse_timdex_filename_filename_success():
         "source-2024-01-01-full-extracted-records-to-index.xml"
     ) == {
         "source": "source",
-        "date": "2024-01-01",
-        "cadence": "full",
+        "run-date": "2024-01-01",
+        "run-type": "full",
         "stage": "extracted",
         "action": "index",
         "index": None,


### PR DESCRIPTION
### Purpose and background context

Create a central utility function to parse TIMDEX "run" details from names of files that are used/created throughout the Transmogrifier A/B Diff workflow. This function replaces the now deprecated `parse_x` functions that were previously implemented within core function modules. Here are the main updates: 

* Utility function [utils.parse_timdex_filename](https://github.com/MITLibraries/transmogrifier-ab-diff/pull/42/files#diff-3257f756c2ef8ad26bddac437d0041e415592ff08a5e6618f1b3b52e369f0259R82-R102)
* Use utility function output to create [`get_transformed_filename` function](https://github.com/MITLibraries/transmogrifier-ab-diff/pull/42/files#diff-7a49d9dbf619fca67eb5ed5ed16b6c62440a4cc6898754cd835d2b819be74ddcR314-R323) in `run_ab_transforms`.
* Use utility function output to [name columns in the collated dataset](https://github.com/MITLibraries/transmogrifier-ab-diff/pull/42/files#diff-1cf5419c409425ac3b8275acb901b7c68cc1131a5b24d5846f477eb967681e55R95-R103) in `collate_ab_transforms`.

### How can a reviewer manually see the effects of these changes?
Run `make test` and confirm all unit tests are passing.

### Includes new or updated dependencies?
NO

### Changes expectations for external applications?
NO

### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/TIMX-380
- https://mitlibraries.atlassian.net/browse/TIMX-365

### Developer
- [X] All new ENV is documented in README
- [ ] All new ENV has been added to staging and production environments
- [X] All related Jira tickets are linked in commit message(s)
- [X] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer(s)
- [ ] The commit message is clear and follows our guidelines (not just this PR message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The provided documentation is sufficient for understanding any new functionality introduced
- [ ] Any manual tests have been performed **or** provided examples verified
- [ ] New dependencies are appropriate or there were no changes

