### PR TITLE
TIMX 379 - CSV for input files support and helpers

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -15,6 +15,7 @@ types-docker = "*"
 types-pygit2 = "*"
 flask = "*"
 jsondiff = "*"
+boto3 = "*"
 
 [dev-packages]
 black = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "49987b97784dac1b79e294756e488689897dda724ffea6cfc0263b1256f914c8"
+            "sha256": "f69aed4c7e9fc70ed7cd5699d9903216597857c291f59d98715b3602e796033e"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -23,6 +23,23 @@
             ],
             "markers": "python_version >= '3.8'",
             "version": "==1.8.2"
+        },
+        "boto3": {
+            "hashes": [
+                "sha256:a839ce09a844d92e0039f95851e88da9df80c89ebb4c7818b3e78247fd97a8a7",
+                "sha256:c9bab807b372d5b076d6aeb1d6513131fa0b74e32d8895128f8568b6521296ea"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.8'",
+            "version": "==1.35.46"
+        },
+        "botocore": {
+            "hashes": [
+                "sha256:8bbc9a55cae65a8db7f2e33ff087f4dbfc13fce868e8e3c5273ce9af367a555a",
+                "sha256:8c0ff5fdd611a28f5752189d171c69690dbc484fa06d74376890bb0543ec3dc1"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==1.35.46"
         },
         "certifi": {
             "hashes": [
@@ -426,6 +443,14 @@
             "markers": "python_version >= '3.7'",
             "version": "==3.1.4"
         },
+        "jmespath": {
+            "hashes": [
+                "sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980",
+                "sha256:90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==1.0.1"
+        },
         "jsondiff": {
             "hashes": [
                 "sha256:658d162c8a86ba86de26303cd86a7b37e1b2c1ec98b569a60e2ca6180545f7fe",
@@ -558,7 +583,7 @@
                 "sha256:faa88bc527d0f097abdc2c663cddf37c05a1c2f113716601555249805cf573f1",
                 "sha256:fc44e3c68ff00fd991b59092a54350e6e4911152682b4782f68070985aa9e648"
             ],
-            "markers": "python_version >= '3.12'",
+            "markers": "python_version >= '3.10'",
             "version": "==2.1.2"
         },
         "pandas": {
@@ -778,6 +803,14 @@
             ],
             "markers": "python_version >= '3.8'",
             "version": "==2.32.3"
+        },
+        "s3transfer": {
+            "hashes": [
+                "sha256:263ed587a5803c6c708d3ce44dc4dfedaab4c1a32e8329bab818933d79ddcf5d",
+                "sha256:4f50ed74ab84d474ce614475e0b8d5047ff080810aac5d01ea25231cfc944b0c"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==0.10.3"
         },
         "six": {
             "hashes": [
@@ -1313,7 +1346,7 @@
                 "sha256:faa88bc527d0f097abdc2c663cddf37c05a1c2f113716601555249805cf573f1",
                 "sha256:fc44e3c68ff00fd991b59092a54350e6e4911152682b4782f68070985aa9e648"
             ],
-            "markers": "python_version >= '3.12'",
+            "markers": "python_version >= '3.10'",
             "version": "==2.1.2"
         },
         "packaging": {

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ WEBAPP_HOST=# host for flask webapp
 WEBAPP_PORT=# port for flask webapp
 TRANSMOGRIFIER_MAX_WORKERS=# max number of Transmogrifier containers to run in parallel; default is 6
 TRANSMOGRIFIER_TIMEOUT=# timeout for a single Transmogrifier container; default is 5 hours
+TIMDEX_BUCKET=# when using CLI command 'timdex-sources-csv', this is required to know what TIMDEX bucket to use
 ```
 
 ## CLI commands
@@ -143,7 +144,10 @@ Usage: -c run-diff [OPTIONS]
 
 Options:
   -d, --job-directory TEXT  Job directory to create.  [required]
-  -i, --input-files TEXT    Input files to transform.  [required]
+  -i, --input-files TEXT    Input files to transform.  This may be a comma
+                            separated list of input files, or a local CSV file
+                            that provides a list of files.  [required]
+  -m, --message TEXT        Message to describe Run.
   -h, --help                Show this message and exit.
 ```
 
@@ -158,3 +162,23 @@ Options:
   -h, --help                Show this message and exit.
 ```
 
+### `timdex-sources-csv`
+```text
+Usage: -c timdex-sources-csv [OPTIONS]
+
+  Generate a CSV of ordered extract files for all, or a subset, of TIMDEX
+  sources.
+
+  This CSV may be passed to CLI command 'run-diff' for the '-i / --input-
+  files' argument, serving as the list of input files for the run.
+
+  This command requires that env var 'TIMDEX_BUCKET' is set to establish what
+  S3 bucket to use for scanning.  The appropriate AWS credentials are also
+  needed to be set.
+
+Options:
+  -o, --output-file TEXT  Output filepath for CSV.  [required]
+  -s, --sources TEXT      Optional comma separated list of sources to include.
+                          Default is all.
+  -h, --help              Show this message and exit.
+```

--- a/abdiff/cli.py
+++ b/abdiff/cli.py
@@ -19,7 +19,7 @@ from abdiff.core import (
 )
 from abdiff.core import init_job as core_init_job
 from abdiff.core.utils import read_job_json
-from abdiff.helpers.timdex_sources import get_ordered_extracted_files_all_sources
+from abdiff.extras.timdex_sources import get_ordered_extracted_files_all_sources
 from abdiff.webapp.app import app
 
 logger = logging.getLogger(__name__)

--- a/abdiff/config.py
+++ b/abdiff/config.py
@@ -15,6 +15,7 @@ class Config:
         "WEBAPP_PORT",
         "TRANSMOGRIFIER_MAX_WORKERS",
         "TRANSMOGRIFIER_TIMEOUT",
+        "TIMDEX_BUCKET",
     )
 
     def __getattr__(self, name: str) -> Any:  # noqa: ANN401
@@ -44,6 +45,18 @@ class Config:
         """Timeout for a single Transmogrifier container."""
         timeout = self.TRANSMOGRIFIER_TIMEOUT or 60 * 60 * 5  # 5 hours default
         return int(timeout)
+
+    @property
+    def active_timdex_sources(self) -> list[str]:
+        return [
+            "alma",
+            "aspace",
+            "dspace",
+            "gismit",
+            "gisogm",
+            "libguides",
+            "researchdatabases",
+        ]
 
 
 def configure_logger(logger: logging.Logger, *, verbose: bool) -> str:

--- a/abdiff/helpers/timdex_sources.py
+++ b/abdiff/helpers/timdex_sources.py
@@ -29,7 +29,7 @@ def get_extracted_files_for_source(
             for obj in page["Contents"]:
                 if not obj["Key"].endswith("/"):  # skip folders
                     s3_uri = f"s3://{bucket}/{obj['Key']}"
-                    files.append(s3_uri)  # noqa: PERF401
+                    files.append(s3_uri)
 
     # filter where "extracted" in filename
     return [file for file in files if "extracted" in file]

--- a/abdiff/helpers/timdex_sources.py
+++ b/abdiff/helpers/timdex_sources.py
@@ -1,0 +1,93 @@
+"""abdiff.helpers.timdex_sources"""
+
+import datetime
+import logging
+import re
+
+import boto3  # type: ignore[import-untyped]
+
+from abdiff.config import Config
+
+logger = logging.getLogger(__name__)
+
+CONFIG = Config()
+
+
+def get_extracted_files_for_source(
+    source: str,
+    bucket: str = CONFIG.TIMDEX_BUCKET,
+) -> list[str]:
+    """List S3 URIs for extract files in TIMDEX S3 bucket for a given source."""
+    s3_client = boto3.client("s3")
+    files = []
+
+    paginator = s3_client.get_paginator("list_objects_v2")
+    page_iterator = paginator.paginate(Bucket=bucket, Prefix=source)
+
+    for page in page_iterator:
+        if "Contents" in page:
+            for obj in page["Contents"]:
+                if not obj["Key"].endswith("/"):  # skip folders
+                    s3_uri = f"s3://{bucket}/{obj['Key']}"
+                    files.append(s3_uri)  # noqa: PERF401
+
+    # filter where "extracted" in filename
+    return [file for file in files if "extracted" in file]
+
+
+def get_ordered_extracted_files_since_last_full_run(source: str) -> list[str]:
+    """Get extract files, from last full run, through all daily runs, for a source."""
+    logger.info(f"Retrieving ordered extracted files for source: '{source}'")
+    all_files = get_extracted_files_for_source(source)
+
+    # Find all full extract files and extract their dates
+    full_extracts = [f for f in all_files if _is_full_extract(f)]
+    if not full_extracts:
+        logger.warning("No full extracts found.")
+        return []
+
+    # Extract dates from full extract files and find the most recent date
+    full_extract_dates = [_extract_date(f) for f in full_extracts]
+    most_recent_full_date = max(full_extract_dates)
+
+    # Collect all full extract files with the most recent date
+    most_recent_full_files = sorted(
+        f for f in full_extracts if _extract_date(f) == most_recent_full_date
+    )
+
+    # Collect all daily extracts from the cutoff date onwards
+    recent_daily_extracts = sorted(
+        f
+        for f in all_files
+        if _is_daily_extract(f) and _extract_date(f) >= most_recent_full_date
+    )
+
+    # Combine full extracts and daily extracts
+    ordered_files = most_recent_full_files + recent_daily_extracts
+    logger.info(f"Total files retrieved: {len(ordered_files)}")
+    return ordered_files
+
+
+def _is_full_extract(filename: str) -> bool:
+    return "-full-" in filename
+
+
+def _is_daily_extract(filename: str) -> bool:
+    return "-daily-" in filename
+
+
+def _extract_date(filename: str) -> datetime.datetime:
+    date_string = re.findall(r".+?(\d{4}-\d{2}-\d{2})", filename)[0]
+    return datetime.datetime.strptime(date_string, "%Y-%m-%d").astimezone(datetime.UTC)
+
+
+def get_ordered_extracted_files_all_sources(
+    sources: list[str] | None = None,
+) -> dict[str, list[str]]:
+    """Get ordered extract files for all TIMDEX sources."""
+    if not sources:
+        sources = CONFIG.active_timdex_sources
+    return {
+        source: get_ordered_extracted_files_since_last_full_run(source=source)
+        for source in sources
+    }


### PR DESCRIPTION
### Purpose and background context

This PR partially addresses [TIMX-379](https://mitlibraries.atlassian.net/browse/TIMX-379) which is concerned with performing large / complex runs.

**The goal**: perform a run of ABDiff where the input files are for ALL sources in TIMDEX, going back to their most recent "full" run, and then all subsequent "daily" runs.

This full list of input files is around 1.6k (very many!) and exposes two challenges:
1. creating this list of input files
2. passing these to the CLI command `run-diff` as comma seperated values for `-i / --input-files`

**This PR addresses this in two ways**:
1. create a new CLI command `timdex-sources-csv` that will generate a CSV of input files based on some criteria
2. updates CLI command `run-diff` to support a CSV for the `-i / --input-files` argument for input files

I would highlight a couple of characteristics of these changes:
- they are mostly purely additive, meaning no original logic or behavior is changed
- they are not well tested

I anticipate that the "not well tested" part makes some nervous, but as purely additive changes for just initiating runs, I would propose that's okay.  These changes support larger runs for testing at scale, which in turn focus and direct work on bugs and features that do warrant more rigourous testing. 

### How can a reviewer manually see the effects of these changes?

1- Create a job
```shell
pipenv run abdiff --verbose init-job -d output/jobs/csv -a 008e20c -b 395e612
```

2- Set AWS credentials for production in `.env` file

3- Set additional env var required for CLI command `timdex-sources-csv`:
```text
TIMDEX_BUCKET=timdex-extract-prod-300442551476
```

4- Run new CLI command to generate a CSV file of input files for `libguides` and `gismit` sources
```shell
pipenv run abdiff --verbose timdex-sources-csv \
-o output/jobs/csv/test.csv \
-s libguides,gismit
```
- observe that new CSV file created at `output/jobs/csv/test.csv` contains ~182 S3 URIs
- files are ordered by last "full" run then all following "daily" runs

5- Run diff and pass CSV
```shell
pipenv run abdiff --verbose run-diff \
-d output/jobs/csv \
-i output/jobs/csv/test.csv
```
- observe that run uses CSVs
- though 182 input files (so 364 containers), runs pretty quick given small input file sizes, about 2-3 minutes total time

### Includes new or updated dependencies?
YES

### Changes expectations for external applications?
NO

### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/TIMX-379

### Developer
- [X] All new ENV is documented in README
- [X] All new ENV has been added to staging and production environments
- [X] All related Jira tickets are linked in commit message(s)
- [X] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer(s)
- [ ] The commit message is clear and follows our guidelines (not just this PR message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The provided documentation is sufficient for understanding any new functionality introduced
- [ ] Any manual tests have been performed **or** provided examples verified
- [ ] New dependencies are appropriate or there were no changes



[TIMX-379]: https://mitlibraries.atlassian.net/browse/TIMX-379?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ