### PR TITLE
TIMX 387 - Fix bug in Transmogrifier output filename

### DIFF
--- a/abdiff/core/run_ab_transforms.py
+++ b/abdiff/core/run_ab_transforms.py
@@ -153,13 +153,14 @@ def run_all_docker_containers(
     with ThreadPoolExecutor(max_workers=CONFIG.transmogrifier_max_workers) as executor:
         for input_file in input_files:
             filename_details = parse_timdex_filename(input_file)
+            output_file = get_transformed_filename(filename_details)
             for docker_image, transformed_directory in run_configs:
                 args = (
                     docker_image,
                     transformed_directory,
                     str(filename_details["source"]),
                     input_file,
-                    get_transformed_filename(filename_details),
+                    output_file,
                     docker_client,
                 )
                 tasks.append(
@@ -353,18 +354,13 @@ def validate_output(
 
 def get_transformed_filename(filename_details: dict) -> str:
     """Get transformed filename using extract filename details."""
-    filename_details.update(
-        stage="transformed",
-        index=f"_{sequence}" if (sequence := filename_details["index"]) else "",
-    )
-    output_filename = (
-        "{source}-{run_date}-{run_type}-{stage}-records-to-{action}{index}.json"
-    )
-    return output_filename.format(
-        source=filename_details["source"],
-        run_date=filename_details["run-date"],
-        run_type=filename_details["run-type"],
-        stage=filename_details["stage"],
-        index=filename_details["index"],
-        action=filename_details["action"],
+    return (
+        "{source}-{run_date}-{run_type}-{stage}-records-to-{action}{index}.json".format(
+            source=filename_details["source"],
+            run_date=filename_details["run-date"],
+            run_type=filename_details["run-type"],
+            stage="transformed",
+            index=f"_{sequence}" if (sequence := filename_details["index"]) else "",
+            action=filename_details["action"],
+        )
     )


### PR DESCRIPTION
### Purpose and background context

This PR addresses a small bug where the helper function `run_ab_transforms.get_transformed_filename()` was modifying a dictionary _twice_ given the same dictionary for A and B records.

This was resulting in an extra underscore getting added to the output filenames for the B version of the record, specifically when the file had an index (e.g. `_01` for Alma input files).

Before:
```
alma-2023-03-09-full-transformed-records-to-index_07.json  # A version
alma-2023-03-09-full-transformed-records-to-index__07.json # B version
```

After:
```
alma-2023-03-09-full-transformed-records-to-index_07.json  # A version
alma-2023-03-09-full-transformed-records-to-index_07.json # B version
```

### How can a reviewer manually see the effects of these changes?

The following small job should be fully successful, where prior it would fail a validation check because _all_ "B" records would be missed during joining.

NOTE: while this example would fully fail, in larger jobs, it would not fail validation because an _entire_ subset of records were not missing A or B versions.  It revealed itself as an unusually high number of A or B records being NULL after Transmogrifier, which was also not accurate or representative.

1- Set AWS prod credentials

2- Create job
```shell
pipenv run abdiff --verbose init-job -d output/jobs/fnamebug -a 008e20c -b 3f77c7c
```

3- Run diff for input file that has underscore (index) in filename
```shell
pipenv run abdiff --verbose run-diff \
-d output/jobs/fnamebug -m "testing 3 small alma files" --download-files \
-i s3://timdex-extract-prod-300442551476/alma/alma-2023-06-07-daily-extracted-records-to-index_01.xml,s3://timdex-extract-prod-300442551476/alma/alma-2023-06-07-daily-extracted-records-to-index_02.xml,s3://timdex-extract-prod-300442551476/alma/alma-2023-06-07-daily-extracted-records-to-index_03.xml
```

### Includes new or updated dependencies?
NO

### Changes expectations for external applications?
NO

### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/TIMX-387

### Developer
- [X] All new ENV is documented in README
- [X] All new ENV has been added to staging and production environments
- [X] All related Jira tickets are linked in commit message(s)
- [X] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer(s)
- [ ] The commit message is clear and follows our guidelines (not just this PR message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The provided documentation is sufficient for understanding any new functionality introduced
- [ ] Any manual tests have been performed **or** provided examples verified
- [ ] New dependencies are appropriate or there were no changes

