### PR TITLE
Write container logs to separate text files as runs complete

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,10 +188,15 @@ Usage: -c run-diff [OPTIONS]
 
 Options:
   -d, --job-directory TEXT  Job directory to create.  [required]
-  -i, --input-files TEXT    Input files to transform.  This may be a comma
+  -i, --input-files TEXT    Input files to transform. This may be a comma
                             separated list of input files, or a local CSV file
                             that provides a list of files.  [required]
   -m, --message TEXT        Message to describe Run.
+  --download-files          Pass to download input files (or use previously
+                            downloaded input files) from AWS S3. The
+                            downloaded files are stored in a local MinIO S3
+                            server and made available for Transmogrifier to
+                            use.
   -h, --help                Show this message and exit.
 ```
 

--- a/abdiff/cli.py
+++ b/abdiff/cli.py
@@ -141,7 +141,7 @@ def init_job(
     type=str,
     required=True,
     help=(
-        "Input files to transform.  This may be a comma separated list of input files, "
+        "Input files to transform. This may be a comma separated list of input files, "
         "or a local CSV file that provides a list of files."
     ),
 )
@@ -157,8 +157,9 @@ def init_job(
     "--download-files",
     is_flag=True,
     help=(
-        "Pass to download input files from AWS S3 to a local Minio S3 server "
-        "for Transmogrifier to use."
+        "Pass to download input files (or use previously downloaded input files) "
+        "from AWS S3. The downloaded files are stored in a local MinIO S3 server "
+        "and made available for Transmogrifier to use."
     ),
 )
 def run_diff(

--- a/abdiff/core/init_run.py
+++ b/abdiff/core/init_run.py
@@ -20,7 +20,9 @@ def init_run(
     """Function to initialize a new Run as part of a parent Job."""
     run_timestamp = datetime.datetime.now(tz=datetime.UTC).strftime("%Y-%m-%d_%H-%M-%S")
     run_directory = str(Path(job_directory) / "runs" / run_timestamp)
+    logs_directory = str(Path(run_directory) / "logs")
     os.makedirs(run_directory)
+    os.makedirs(logs_directory)
     logger.info(f"Run directory created: {run_directory}")
 
     # clone job data and update with run information

--- a/abdiff/core/init_run.py
+++ b/abdiff/core/init_run.py
@@ -24,6 +24,7 @@ def init_run(
     os.makedirs(run_directory)
     os.makedirs(logs_directory)
     logger.info(f"Run directory created: {run_directory}")
+    logger.info(f"Logs directory created: {logs_directory}")
 
     # clone job data and update with run information
     run_data = read_job_json(job_directory)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,8 +32,9 @@ from abdiff.core.utils import create_subdirectories, load_dataset, write_to_data
 class Container:
     """Stub for docker.models.container.Container object."""
 
-    def __init__(self, id, labels, attrs: dict | None = None):  # noqa: A002
+    def __init__(self, id, short_id, labels, attrs: dict | None = None):  # noqa: A002
         self.id = id
+        self.short_id = short_id
         self.labels = labels
         self.status = "created"
         self.run_duration = 0.5
@@ -56,8 +57,10 @@ class Container:
         if time.time() - self.start_time >= self.run_duration:
             self.status = "exited"
 
-    def logs(self):
+    def logs(self, *, stream: bool = True):
         with open("tests/fixtures/transmogrifier-logs.txt", "rb") as file:
+            if stream:
+                yield from file
             return file.read()
 
     def stop(self):
@@ -110,6 +113,7 @@ class MockedContainerRun:
         if self.errors:
             return Container(
                 id=container_id,
+                short_id=container_id[:3],
                 labels={
                     "docker_image": image_name,
                     "source": "source",
@@ -119,6 +123,7 @@ class MockedContainerRun:
             )
         return Container(
             id=container_id,
+            short_id=container_id[:3],
             labels={
                 "docker_image": image_name,
                 "source": "source",
@@ -277,6 +282,7 @@ def mocked_docker_container_and_image(
 def mocked_docker_container_a():
     return Container(
         id="abc123",
+        short_id="abc",
         labels={
             "docker_image": "transmogrifier-example-job-1-abc123:latest",
             "source": "source",
@@ -289,6 +295,7 @@ def mocked_docker_container_a():
 def mocked_docker_container_b():
     return Container(
         id="def456",
+        short_id="def",
         labels={
             "docker_image": "transmogrifier-example-job-1-def456:latest",
             "source": "source",

--- a/tests/test_run_ab_transforms.py
+++ b/tests/test_run_ab_transforms.py
@@ -10,13 +10,13 @@ from abdiff.core.exceptions import (
     OutputValidationError,
 )
 from abdiff.core.run_ab_transforms import (
-    aggregate_logs,
     collect_container_results,
     get_transformed_filename,
     get_transformed_files,
     run_ab_transforms,
     run_docker_container,
     validate_output,
+    write_log_file,
 )
 from abdiff.core.utils import parse_timdex_filename
 from tests.conftest import MockedContainerRun, MockedFutureSuccess
@@ -34,18 +34,19 @@ def test_run_ab_transforms_success(
         )
     )
 
+    input_files = [
+        "s3://timdex-extract-dev/source/source-2024-01-01-daily-extracted-records-to-index.xml"
+    ]
     run_ab_transforms(
         run_directory=run_directory,
         image_tag_a="transmogrifier-example-job-1-abc123:latest",
         image_tag_b="transmogrifier-example-job-1-def456:latest",
-        input_files=[
-            "s3://timdex-extract-dev/source/source-2024-01-01-daily-extracted-records-to-index.xml"
-        ],
+        input_files=input_files,
         docker_client=mocked_docker_client,
     )
 
     assert os.path.exists(run_directory)
-    assert os.path.isfile(Path(run_directory) / "transformed/logs.txt")
+    assert len(os.listdir(Path(run_directory) / "logs")) == len(input_files) * 2
 
     for transformed_directory in ["a", "b"]:
         assert os.path.exists(Path(run_directory) / "transformed" / transformed_directory)
@@ -87,6 +88,7 @@ def test_run_ab_transforms_raise_error_if_containers_failed(
 
 
 def test_run_docker_container_success(
+    run_directory,
     mocked_docker_client,
     mocked_docker_container_and_image,
     create_transformed_directories,
@@ -117,6 +119,7 @@ def test_run_docker_container_success(
     filename_details = parse_timdex_filename(input_file)
     container, _ = run_docker_container(
         docker_image=image_name,
+        run_directory=run_directory,
         transformed_directory=transformed_directory,
         source=filename_details["source"],
         input_file=input_file,
@@ -130,16 +133,104 @@ def test_run_docker_container_success(
     )
 
 
-def test_aggregate_logs_success(
-    run_directory,
-    create_transformed_directories,
-    mocked_docker_container_a,
-    mocked_docker_container_b,
+def test_run_docker_container_timeout_triggered(
+    mocked_docker_client, mocked_docker_container_a
 ):
-    log_file = aggregate_logs(
-        run_directory, containers=[mocked_docker_container_a, mocked_docker_container_b]
+    mocked_docker_client.containers.run.return_value = mocked_docker_container_a
+    mocked_docker_container_a.run_duration = 2
+    timeout = 1
+    _, exception = run_docker_container(
+        "abc123",
+        "run",
+        "abc",
+        "alma",
+        "/tmp/input.xml",
+        "/tmp/output.json",
+        mocked_docker_client,
+        timeout=timeout,
     )
-    assert os.path.exists(log_file)
+    assert isinstance(exception, DockerContainerTimeoutError)
+
+
+def test_run_docker_container_timeout_not_triggered(
+    mocked_docker_client, mocked_docker_container_a
+):
+    mocked_docker_client.containers.run.return_value = mocked_docker_container_a
+    mocked_docker_container_a.run_duration = 2
+    timeout = 3
+    container, _ = run_docker_container(
+        "abc123",
+        "run",
+        "abc",
+        "alma",
+        "/tmp/input.xml",
+        "/tmp/output.json",
+        mocked_docker_client,
+        timeout=timeout,
+    )
+    assert container.status == "exited"
+
+
+def test_run_docker_container_unhandled_error_still_returns_container_and_exception(
+    mocked_docker_client, mocked_docker_container_a
+):
+    mocked_docker_client.containers.run.return_value = mocked_docker_container_a
+
+    mocked_exception = Exception("Error checking container status!")
+    with mock.patch.object(mocked_docker_container_a, "reload") as mocked_reload:
+        mocked_reload.side_effect = mocked_exception
+        container, exception = run_docker_container(
+            "abc123",
+            "run",
+            "abc",
+            "alma",
+            "/tmp/input.xml",
+            "/tmp/output.json",
+            mocked_docker_client,
+        )
+
+    assert container == mocked_docker_container_a
+    assert exception == mocked_exception
+
+
+def test_collect_containers_two_success_return_zero_exceptions(
+    mocked_docker_container_a, mocked_docker_container_b
+):
+    futures = [
+        MockedFutureSuccess(container=mocked_docker_container_a, exception=None),
+        MockedFutureSuccess(container=mocked_docker_container_b, exception=None),
+    ]
+
+    exceptions = collect_container_results(futures)
+    assert len(exceptions) == 0
+
+
+def test_collect_containers_return_exception(
+    mocked_docker_container_a, mocked_docker_container_b
+):
+    mocked_exception = Exception("Container failure!")
+    futures = [
+        MockedFutureSuccess(container=mocked_docker_container_a, exception=None),
+        MockedFutureSuccess(
+            container=mocked_docker_container_b,
+            exception=mocked_exception,
+        ),
+    ]
+    exceptions = collect_container_results(futures)
+
+    assert len(exceptions) == 1
+    assert exceptions[0] == mocked_exception
+
+
+def test_write_log_file_success(run_directory, mocked_docker_container_a):
+    write_log_file(
+        run_directory=run_directory,
+        input_file="s3://timdex-extract-dev/source/source-2024-01-01-daily-extracted-records-to-index.xml",
+        container=mocked_docker_container_a,
+    )
+    assert os.path.exists(
+        Path(run_directory) / "logs/source-2024-01-01-daily-abc-logs.txt"
+    )
 
 
 def test_get_transformed_files_success(
@@ -248,7 +339,7 @@ def test_validate_output_error(ab_files, input_files):
         validate_output(ab_transformed_file_lists=ab_files, input_files=input_files)
 
 
-def test_get_output_filename_success():
+def test_get_transformed_filename_success():
     assert (
         get_transformed_filename(
             {
@@ -265,96 +356,7 @@ def test_get_output_filename_success():
     )
 
 
-def test_run_docker_container_timeout_triggered(
-    mocked_docker_client, mocked_docker_container_a
-):
-    mocked_docker_client.containers.run.return_value = mocked_docker_container_a
-    mocked_docker_container_a.run_duration = 2
-    timeout = 1
-    _, exception = run_docker_container(
-        "abc123",
-        "abc",
-        "alma",
-        "/tmp/input.xml",
-        "/tmp/output.json",
-        mocked_docker_client,
-        timeout=timeout,
-    )
-    assert isinstance(exception, DockerContainerTimeoutError)
-
-
-def test_run_docker_container_timeout_not_triggered(
-    mocked_docker_client, mocked_docker_container_a
-):
-    mocked_docker_client.containers.run.return_value = mocked_docker_container_a
-    mocked_docker_container_a.run_duration = 2
-    timeout = 3
-    container, _ = run_docker_container(
-        "abc123",
-        "abc",
-        "alma",
-        "/tmp/input.xml",
-        "/tmp/output.json",
-        mocked_docker_client,
-        timeout=timeout,
-    )
-    assert container.status == "exited"
-
-
-def test_run_docker_container_unhandled_error_still_returns_container_and_exception(
-    mocked_docker_client, mocked_docker_container_a
-):
-    mocked_docker_client.containers.run.return_value = mocked_docker_container_a
-
-    mocked_exception = Exception("Error checking container status!")
-    with mock.patch.object(mocked_docker_container_a, "reload") as mocked_reload:
-        mocked_reload.side_effect = mocked_exception
-        container, exception = run_docker_container(
-            "abc123",
-            "abc",
-            "alma",
-            "/tmp/input.xml",
-            "/tmp/output.json",
-            mocked_docker_client,
-        )
-
-    assert container == mocked_docker_container_a
-    assert exception == mocked_exception
-
-
-def test_collect_containers_two_success_return_zero_exceptions(
-    mocked_docker_container_a, mocked_docker_container_b
-):
-    futures = [
-        MockedFutureSuccess(container=mocked_docker_container_a, exception=None),
-        MockedFutureSuccess(container=mocked_docker_container_b, exception=None),
-    ]
-
-    containers, exceptions = collect_container_results(futures)
-    assert len(containers) == 2
-    assert containers == [mocked_docker_container_a, mocked_docker_container_b]
-    assert len(exceptions) == 0
-
-
-def test_collect_containers_return_containers_and_exceptions(
-    mocked_docker_container_a, mocked_docker_container_b
-):
-    mocked_exception = Exception("Container failure!")
-    futures = [
-        MockedFutureSuccess(container=mocked_docker_container_a, exception=None),
-        MockedFutureSuccess(
-            container=mocked_docker_container_b,
-            exception=mocked_exception,
-        ),
-    ]
-    containers, exceptions = collect_container_results(futures)
-
-    assert len(containers) == 2
-    assert len(exceptions) == 1
-    assert exceptions[0] == mocked_exception
-
-
-def test_get_output_filename_indexed_success():
+def test_get_transformed_filename_indexed_success():
     assert (
         get_transformed_filename(
             {

--- a/tests/test_run_ab_transforms.py
+++ b/tests/test_run_ab_transforms.py
@@ -134,17 +134,17 @@ def test_run_docker_container_success(
 
 
 def test_run_docker_container_timeout_triggered(
-    mocked_docker_client, mocked_docker_container_a
+    run_directory, mocked_docker_client, mocked_docker_container_a
 ):
     mocked_docker_client.containers.run.return_value = mocked_docker_container_a
     mocked_docker_container_a.run_duration = 2
     timeout = 1
     _, exception = run_docker_container(
         "abc123",
-        "run",
+        run_directory,
         "abc",
         "alma",
-        "/tmp/input.xml",
+        "/tmp/source-2024-01-01-full-extracted-records-to-index.xml",
         "/tmp/output.json",
         mocked_docker_client,
         timeout=timeout,
@@ -163,7 +163,7 @@ def test_run_docker_container_timeout_not_triggered(
         "run",
         "abc",
         "alma",
-        "/tmp/input.xml",
+        "/tmp/source-2024-01-01-full-extracted-records-to-index.xml",
         "/tmp/output.json",
         mocked_docker_client,
         timeout=timeout,


### PR DESCRIPTION
### Purpose and background context
Improve observability of `run_ab_transforms` while running through two main updates:
* Creating log files as containers exit (i.e., as runs are "completed")
* Creating one log file _per_ container

As noted in the ticket, the app currently waits for all containers to exit _before_ writing anything to `logs.txt` and it collects _all_ the logs from the container into a single text file. While this text file may be manageable for small runs, it can become unwieldy in the event of much larger runs. Additionally, the log file was getting removed because it was being saved in the `transformed/` directory, which gets deleted when `PRESERVE_ARTIFACTS="false"`.

Log files per container are stored in a `logs/` folder in the run directory, safe from the cleanup step! This configurations sets the stage for adding a page to the web app dedicated to reviewing logs for each container; this will be addressed as part of [TIMX-368](https://mitlibraries.atlassian.net/browse/TIMX-368).

### How can a reviewer manually see the effects of these changes?

1. Set AWS Prod credentials in `.env`. Include env vars `TIMDEX_BUCKET`.
2. Create job.
   ```shell
   pipenv run abdiff --verbose init-job -d output/jobs/records -a 4fcb617 -b 3f77c7c
   ```
3. Run diff for small example.
   ```shell
   pipenv run abdiff --verbose run-diff -d output/jobs/records -i s3://timdex-extract-prod-300442551476/libguides/libguides-2024-11-13-daily-extracted-records-to-index.xml
   ```
4. Navigate to "records" job directory and run `tree`. You should see the following output.
```shell
├── job.json
└── runs
    └── 2024-11-14_19-24-02
        ├── logs
        │   ├── libguides-2024-11-13-daily-13961f761b56-logs.txt
        │   └── libguides-2024-11-13-daily-9f825efb19fe-logs.txt
        ├── records
        │   └── source=libguides
        │       └── has_diff=true
        │           └── records-0.parquet
        ├── run.duckdb
        └── run.json
   
```
🎉 

### Includes new or updated dependencies?
NO

### Changes expectations for external applications?
NO

### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/TIMX-382

### Developer
- [X] All new ENV is documented in README
- [ ] All new ENV has been added to staging and production environments
- [X] All related Jira tickets are linked in commit message(s)
- [X] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer(s)
- [ ] The commit message is clear and follows our guidelines (not just this PR message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The provided documentation is sufficient for understanding any new functionality introduced
- [ ] Any manual tests have been performed **or** provided examples verified
- [ ] New dependencies are appropriate or there were no changes



[TIMX-368]: https://mitlibraries.atlassian.net/browse/TIMX-368?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ